### PR TITLE
Make DNS text output usable

### DIFF
--- a/src/Command/Domain/Dns/GetByDomainName.php
+++ b/src/Command/Domain/Dns/GetByDomainName.php
@@ -2,11 +2,14 @@
 
 namespace Transip\Api\CLI\Command\Domain\Dns;
 
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Transip\Api\CLI\Command\AbstractCommand;
 use Transip\Api\CLI\Command\Field;
+use Transip\Api\Library\Entity\Domain\DnsEntry;
 
 class GetByDomainName extends AbstractCommand
 {
@@ -22,6 +25,16 @@ class GetByDomainName extends AbstractCommand
     {
         $domainName = $input->getArgument(Field::DOMAIN_NAME);
         $dnsEntries = $this->getTransipApi()->domainDns()->getByDomainName($domainName);
-        $this->output($dnsEntries);
+
+        if ($input->getOption(Field::FORMAT) === 'txt') {
+            $table = new Table($output);
+            $table->setStyle('compact');
+            $table->setRows(array_map(function(DnsEntry $row) {
+                return [$row->getName(), $row->getType(), $row->getExpire(), $row->getContent()];
+            }, $dnsEntries));
+            $table->render();
+        } else {
+            $this->output($dnsEntries);
+        }
     }
 }


### PR DESCRIPTION
This PR makes the output of `domain:dns:getbydomainname --format=txt` actually usable in practical cases.

Sample output:
```sh
$ bin/tipctl domain:dns:getbydomainname -d transipdemonstratie.nl --format=txt
 @                    A     300   37.97.254.27
 @                    AAAA  300   2a01:7c8:3:1337::27
 @                    MX    86400 10 @
 @                    TXT   300   v=spf1 ~all
 ftp                  CNAME 86400 @
 mail                 CNAME 86400 @
 transip-A._domainkey CNAME 3600  _dkim-A.transip.email.
 transip-B._domainkey CNAME 3600  _dkim-B.transip.email.
 transip-C._domainkey CNAME 3600  _dkim-C.transip.email.
 www                  CNAME 86400 @
 _dmarc               TXT   86400 v=DMARC1; p=none;
```
Also fixes https://www.transip.nl/knowledgebase/idee/698-dns-records-zone-file-download/ to some extent (I only installed the CLI because the GUI still doesn't have a "download zonefile" option or add the records to "Download gegevens").

